### PR TITLE
Duplicate Log File Extension

### DIFF
--- a/AWS/AWSUtilities.ps1
+++ b/AWS/AWSUtilities.ps1
@@ -94,8 +94,7 @@ function GetLogDate
     {
         $logDate = get-date ((get-date).AddDays($dayOfWeekNumber * -1)) -f yyyyMMdd
     } 
-    $logName = $logDate + ".txt"
-    return  $logName  
+    return  $logDate 
 }
 #Description: Writes a message to a log file, console
 #Returns: n/a

--- a/AWS/AWSUtilities.ps1
+++ b/AWS/AWSUtilities.ps1
@@ -94,8 +94,7 @@ function GetLogDate
     {
         $logDate = get-date ((get-date).AddDays($dayOfWeekNumber * -1)) -f yyyyMMdd
     } 
-    $logName = $logDate + ".txt"
-    return  $logName  
+    return  $logDate  
 }
 #Description: Writes a message to a log file, console
 #Returns: n/a

--- a/AWS/AWSUtilities.ps1
+++ b/AWS/AWSUtilities.ps1
@@ -94,7 +94,8 @@ function GetLogDate
     {
         $logDate = get-date ((get-date).AddDays($dayOfWeekNumber * -1)) -f yyyyMMdd
     } 
-    return  $logDate  
+    $logName = $logDate + ".txt"
+    return  $logName  
 }
 #Description: Writes a message to a log file, console
 #Returns: n/a


### PR DESCRIPTION
Resolved issue with log file name having redundant .txt extension.